### PR TITLE
Add Experimental target to build (WebAssembly)

### DIFF
--- a/llvm.rb
+++ b/llvm.rb
@@ -52,13 +52,6 @@ class Llvm < Formula
       end
     end
   
-    bottle do
-      cellar :any
-      sha256 "e3e64458543bfe1d74820523d5878d55bef3aaad4f06a05464ea910ea9420864" => :mojave
-      sha256 "5eb7a6eebe9ebfa25a3a0d4365e0dc04fb72ed65be4bbc867c7a92d968de3e21" => :high_sierra
-      sha256 "d00b3cb887d22294ee85abec309ad4c2dec2763a3cf06cb22a7866d9415433ac" => :sierra
-    end
-  
     # Clang cannot find system headers if Xcode CLT is not installed
     pour_bottle? do
       reason "The bottle needs the Xcode CLT to be installed."

--- a/llvm.rb
+++ b/llvm.rb
@@ -178,6 +178,7 @@ class Llvm < Formula
         -DLLVM_INSTALL_UTILS=ON
         -DLLVM_OPTIMIZED_TABLEGEN=ON
         -DLLVM_TARGETS_TO_BUILD=all
+        -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
         -DWITH_POLLY=ON
         -DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_lib}/libffi-#{Formula["libffi"].version}/include
         -DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}


### PR DESCRIPTION
LLVM7 supports wasm target as experimental target for now. 

 This PR just add `-  DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly` :-> 