### PR TITLE
Adjust formula to work on High Sierra, and not have a name clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Homebrew formula for installing LLVM 7 with WASM support. Required for using Tin
 
 ```
 brew tap tinygo-org/tools
-brew install llvm
+brew install llvm7
 ```

--- a/llvm7.rb
+++ b/llvm7.rb
@@ -1,4 +1,4 @@
-class Llvm < Formula
+class Llvm7 < Formula
     desc "Next-gen compiler infrastructure"
     homepage "https://llvm.org/"
   
@@ -98,8 +98,6 @@ class Llvm < Formula
       end
     end
   
-    keg_only :provided_by_macos
-  
     option "with-lldb", "Build LLDB debugger"
   
     # https://llvm.org/docs/GettingStarted.html#requirement
@@ -116,13 +114,7 @@ class Llvm < Formula
         :url      => "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt",
       }]
     end
-  
-    # According to the official llvm readme, GCC 4.7+ is required
-    fails_with :gcc_4_2
-    ("4.3".."4.6").each do |n|
-      fails_with :gcc => n
-    end
-  
+
     def install
       # Apple's libstdc++ is too old to build LLVM
       ENV.libcxx if ENV.compiler == :clang


### PR DESCRIPTION
Removing the gcc check seems to be needed, otherwise this error occurs:

```bash
$ brew tap tinygo-org/homebrew-tools
Updating Homebrew...
==> Tapping tinygo-org/tools
Cloning into '/usr/local/Homebrew/Library/Taps/tinygo-org/homebrew-tools'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/tinygo-org/homebrew-tools/llvm.rb
Calling fails_with :gcc_4_2 is disabled! There is no replacement.
Please report this to the tinygo-org/tools tap:
  /usr/local/Homebrew/Library/Taps/tinygo-org/homebrew-tools/llvm.rb:121

Error: Cannot tap tinygo-org/tools: invalid syntax in tap!
$
```

Renaming the formula to llvm7 seems sensible too, for avoiding a name clash with the Homebrew-core llvm formula this was based upon.