### PR TITLE
Support linux

### DIFF
--- a/tinygo.rb
+++ b/tinygo.rb
@@ -3,8 +3,13 @@ class Tinygo < Formula
     homepage "https://tinygo.org/"
     version "0.7.1"
   
-    url "https://github.com/tinygo-org/tinygo/releases/download/v0.7.1/tinygo0.7.1.darwin-amd64.tar.gz"
-    sha256 "30caa68daf25316a241eb6dd8801529d01868248fd1e11d38f1f7276c652ad56"
+    if OS.mac?
+        url "https://github.com/tinygo-org/tinygo/releases/download/v#{version}/tinygo#{version}.darwin-amd64.tar.gz"
+        sha256 "30caa68daf25316a241eb6dd8801529d01868248fd1e11d38f1f7276c652ad56"
+    elsif OS.linux?
+        url "https://github.com/tinygo-org/tinygo/releases/download/v#{version}/tinygo#{version}.linux-amd64.tar.gz"
+        sha256 "2cc120bc84c79c8a861d405a6fc8cb87b9025e249d76044bdb76c986fed998d0"
+    end
     
     bottle :unneeded
   

--- a/tinygo.rb
+++ b/tinygo.rb
@@ -3,6 +3,8 @@ class Tinygo < Formula
     homepage "https://tinygo.org/"
     version "0.7.1"
   
+    depends_on "llvm"
+
     if OS.mac?
         url "https://github.com/tinygo-org/tinygo/releases/download/v#{version}/tinygo#{version}.darwin-amd64.tar.gz"
         sha256 "30caa68daf25316a241eb6dd8801529d01868248fd1e11d38f1f7276c652ad56"


### PR DESCRIPTION
Homebrew officialy supports linux since 2.0.0 release and this PR makes it possible to install `tinygo` via `brew` on linux too.