### PR TITLE
Explicitly depend on LLVM 8

### DIFF
--- a/tinygo.rb
+++ b/tinygo.rb
@@ -3,7 +3,7 @@ class Tinygo < Formula
     homepage "https://tinygo.org/"
     version "0.9.0"
   
-    depends_on "llvm"
+    depends_on "llvm@8"
 
     if OS.mac?
         url "https://github.com/tinygo-org/tinygo/releases/download/v#{version}/tinygo#{version}.darwin-amd64.tar.gz"


### PR DESCRIPTION
Otherwise it will try to install LLVM 9, which is not yet supported.