### PR TITLE
Also copy wasm-opt to bin

### DIFF
--- a/tinygo.rb
+++ b/tinygo.rb
@@ -13,6 +13,7 @@ class Tinygo < Formula
 
     def install
         libexec.install "bin/tinygo"
+        bin.install "bin/wasm-opt"
         (bin/"tinygo").write_env_script libexec/"tinygo",
             :TINYGOROOT => prefix
         lib.install Dir["lib/*"]


### PR DESCRIPTION
Should fix "error: could not find wasm-opt, set the WASMOPT environment variable to override" seen in 0.21.0.