### PR TITLE
Fix whitespace and extra end keyword

### DIFF
--- a/tinygo.rb
+++ b/tinygo.rb
@@ -14,7 +14,6 @@ class Tinygo < Formula
             url "https://github.com/tinygo-org/tinygo/releases/download/v#{version}/tinygo#{version}.darwin-amd64.tar.gz"
             sha256 "ed871e55a57b7c0e0304a215214fc507bdd68a4655d99053f344463360183bd5"
         end
-      end
     end
     on_linux do
         url "https://github.com/tinygo-org/tinygo/releases/download/v#{version}/tinygo#{version}.linux-amd64.tar.gz"
@@ -33,5 +32,5 @@ class Tinygo < Formula
     test do
         system "#{bin}/tinygo", "version"
     end
-  end
+end
   


### PR DESCRIPTION
I hit a Ruby error trying to upgrade to 0.3.1. This PR fixes it.

``` console
$ brew upgrade tinygo
Error: tinygo-org/tools/tinygo: /opt/homebrew/Library/Taps/tinygo-org/homebrew-tools/tinygo.rb:36: syntax error, unexpected `end', expecting end-of-input
  end
  ^~~
```